### PR TITLE
Move tokio-openssl to new tokio-io crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-openssl"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/tokio-openssl"
@@ -14,3 +14,4 @@ An implementation of SSL streams for Tokio backed by OpenSSL
 openssl = "0.9"
 futures = "0.1"
 tokio-core = "0.1"
+tokio-io = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-openssl"
-version = "0.1.1"
+version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/tokio-openssl"


### PR DESCRIPTION
When developing [tokio-cassandra](http://github.com/nhellwig/tokio-cassandra) we moved to the new tokio-io crate. Since we are also using tokio-openssl for SSL connections we needed to move the implementation there also to tokio-io.  

Our [tests](https://github.com/nhellwig/tokio-cassandra/blob/master/bin/integration-test.sh#L58) against SSL are working [(Travis Run)](https://travis-ci.org/nhellwig/tokio-cassandra/jobs/212034279#L1387).  

Since I don't have expert knowledge in SSL / tokio-futures I think especially the shutdown implementation of AsyncWrite should be reviewed.  

This Pull-Request will help us to continue on [tokio-cassandra](http://github.com/nhellwig/tokio-cassandra)

Thanks Niko