### PR TITLE
remove dead code and update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ An implementation of SSL streams for Tokio backed by OpenSSL
 """
 
 [dependencies]
-openssl = "0.9.14"
-futures = "0.1.11"
-tokio-core = "0.1.6"
+openssl = "0.9"
+futures = "0.1"
+tokio-core = "0.1"
 tokio-io = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ An implementation of SSL streams for Tokio backed by OpenSSL
 """
 
 [dependencies]
-openssl = "0.9"
-futures = "0.1"
-tokio-core = "0.1"
-tokio-io = "0.1"
+openssl = "0.9.19"
+futures = "0.1.16"
+tokio-core = "0.1.9"
+tokio-io = "0.1.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,6 @@ use futures::{Poll, Future, Async};
 use openssl::ssl::{self, SslAcceptor, SslConnector, ConnectConfiguration, Error, HandshakeError,
                    ShutdownResult};
 use tokio_io::{AsyncRead, AsyncWrite};
-#[allow(deprecated)]
-use tokio_core::io::Io;
 
 /// A wrapper around an underlying raw stream which implements the SSL
 /// protocol.
@@ -164,10 +162,6 @@ impl<S: Read + Write> Write for SslStream<S> {
     fn flush(&mut self) -> io::Result<()> {
         self.inner.flush()
     }
-}
-
-#[allow(deprecated)]
-impl<S: Io> Io for SslStream<S> {
 }
 
 impl<S: AsyncRead + AsyncWrite> AsyncRead for SslStream<S> {


### PR DESCRIPTION
The methods that were being added by implementing the `Io` trait seem to have been removed in tokio_io, so there's no need to implement that trait any more as far as I can tell.