### PR TITLE
Make futures return HandshakeError

### DIFF
--- a/tests/google.rs
+++ b/tests/google.rs
@@ -4,6 +4,7 @@ extern crate tokio;
 extern crate tokio_openssl;
 extern crate tokio_io;
 
+use std::error::Error;
 use std::io;
 use std::net::ToSocketAddrs;
 
@@ -21,7 +22,10 @@ macro_rules! t {
     })
 }
 
-fn openssl2io(e: openssl::ssl::Error) -> io::Error {
+fn openssl2io<E>(e: E) -> io::Error
+where
+    E: Error + 'static + Sync + Send,
+{
     io::Error::new(io::ErrorKind::Other, e)
 }
 


### PR DESCRIPTION
The WouldBlock variant will never be returned since this crate handles
that case, but the extra information in the other variants is important.
For example, you'll get more specific information with this change after
a certificate verification failure.