### PR TITLE
Add SslStream::from_raw_parts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ An implementation of SSL streams for Tokio backed by OpenSSL
 """
 
 [dependencies]
-openssl = "0.10.1"
+openssl = "0.10.30"
+openssl-sys = "0.9.58"
 tokio = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
This change adds `SslStream::from_raw_parts()`, which makes use of a similar function that was added to version 0.10.30 of the `openssl` crate: https://github.com/sfackler/rust-openssl/blob/master/openssl/src/ssl/mod.rs#L3484